### PR TITLE
fix: the argument model_path of ModuleBase.load() may be either a ModuleConfig object or a str

### DIFF
--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -443,14 +443,14 @@ class TextGeneration(ModuleBase):
     @classmethod
     def load(
         cls,
-        model_path: str,
+        model_path: Union[str, ModuleConfig],
         torch_dtype: str = None,
     ) -> "TextGeneration":
         """Function to load text-generation model
 
         Args:
-            model_path: str
-                Path to the model to be loaded.
+            model_path:
+                Path to the model to be loaded or the Model configuration
             torch_dtype: str
                 Torch data type to be used when loading the model.
         Returns:
@@ -468,7 +468,11 @@ class TextGeneration(ModuleBase):
         base_model_path = config.get("artifact_path")
         error.type_check("<NLP35174683E>", str, base_model_path=base_model_path)
 
-        base_model_path = os.path.join(model_path, base_model_path)
+        path_to_model_config = model_path
+        if isinstance(model_path, ModuleConfig):
+            path_to_model_config = model_path.model_path
+
+        base_model_path = os.path.join(path_to_model_config, base_model_path)
         error.dir_check("<NLP01983374E>", base_model_path)
         return cls.bootstrap(base_model_path, torch_dtype)
 

--- a/caikit_nlp/modules/text_generation/text_generation_tgis.py
+++ b/caikit_nlp/modules/text_generation/text_generation_tgis.py
@@ -139,15 +139,15 @@ class TextGenerationTGIS(ModuleBase):
         )
 
     @classmethod
-    def load(cls, model_path: str, load_backend: BackendBase) -> "TextGeneration":
+    def load(cls, model_path: Union[str, ModuleConfig], load_backend: BackendBase) -> "TextGeneration":
         """Function to load text-generation model. Note, this only loads
         "remote" style model, i.e the cakit-model that doesn't
         necessarily required to have actual artifacts in it
         and thus only saves them in "remote" format.
 
         Args:
-            model_path: str
-                Path to the model to be loaded.
+            model_path:
+                Path to the model to be loaded or the Model configuration
             load_backend: BackendBase
                 Backend object to be used to run inference with.
         Returns:
@@ -160,7 +160,10 @@ class TextGenerationTGIS(ModuleBase):
         tgis_backend = config.tgis_backend or load_backend
         artifacts_path = config.artifact_path
         if artifacts_path:
-            model_name = os.path.join(model_path, artifacts_path)
+            path_to_model_config = model_path
+            if isinstance(model_path, ModuleConfig):
+                path_to_model_config = model_path.model_path
+            model_name = os.path.join(path_to_model_config, artifacts_path)
             error.dir_check("<NLP01983374E>", model_name)
             log.debug("Loading with on-disk artifacts: %s", model_name)
         else:

--- a/caikit_nlp/modules/tokenization/regex_sentence_splitter.py
+++ b/caikit_nlp/modules/tokenization/regex_sentence_splitter.py
@@ -24,6 +24,8 @@ from caikit.interfaces.nlp.data_model import Token, TokenizationResults
 from caikit.interfaces.nlp.tasks import TokenizationTask
 import alog
 
+from typing import Union
+
 log = alog.use_channel("RGX_SNT_SPLT")
 error = error_handler.get(log)
 
@@ -84,18 +86,22 @@ class RegexSentenceSplitter(ModuleBase):
             module_saver.update_config(config_options)
 
     @classmethod
-    def load(cls, model_path: str) -> "RegexSentenceSplitter":
+    def load(cls, model_path: Union[str, ModuleConfig]) -> "RegexSentenceSplitter":
         """Load a regex sentence splitter model.
 
         Args:
-            model_path: str
-                Path to the model to be loaded.
+            model_path:
+                Path to the model to be loaded or the Model configuration
 
         Returns:
             RegexSentenceSplitter
                 Instance of this class built from the on disk model.
         """
-        config = ModuleConfig.load(os.path.abspath(model_path))
+        if isinstance(model_path, ModuleConfig):
+            config = model_path
+        else:
+            config = ModuleConfig.load(os.path.abspath(model_path))
+
         return cls(regex_str=config.regex_str)
 
     def run(self, text: str) -> TokenizationResults:


### PR DESCRIPTION
When using `artifact_path` to load weights from a path with one of the text_generation ModuleBases the caikit runtime emits the following error:


> {"channel": "LLOAD", "exception": null, "level": "warning", "log_code": "`<COR98539580W>`", "message": "DEPRECATION: Loading f9181353-4ccf-4572-bd1e-f12bcda26792 failed with ModuleConfig. Using model_path. expected str, bytes or os.PathLike object, not ModuleConfig", "num_indent": 0, "thread_id": 140699291752000, "timestamp": "2023-10-27T11:21:44.284465"}

The source of the exception is `os.path.join` in https://github.com/VassilisVassiliadis/caikit-nlp/blob/4f42230832777ac9667700fba5254d6452942ce4/caikit_nlp/modules/text_generation/text_generation_local.py#L471

`model_path` is a ModuleConfig object instead of a `str`.

**Changes**

- Update load() methods to support both `str` and `ModuleConfig` types for their `model_path` argument